### PR TITLE
chore: fix github typo

### DIFF
--- a/.dumi/theme/layouts/GlobalLayout.tsx
+++ b/.dumi/theme/layouts/GlobalLayout.tsx
@@ -45,7 +45,7 @@ const GlobalLayout: React.FC = () => {
 
   useEffect(() => {
     createLinkIntervalRef.current = window.setInterval(() => {
-      createLink('Github', 'https://github.com/OpenSPG/openspg', 1);
+      createLink('GitHub', 'https://github.com/OpenSPG/openspg', 1);
       const result = createLink('OpenKG', 'http://openkg.cn/', 5);
       if (result) clearInterval(createLinkIntervalRef.current);
     }, 50);


### PR DESCRIPTION
GitHub 是企业名字，算是专有名字，不能出错，类似的有 iPhone、iOS 等。